### PR TITLE
When host option is specified it will be used instead of the default when creating the URI object

### DIFF
--- a/lib/WWW/Pusher.pm
+++ b/lib/WWW/Pusher.pm
@@ -22,11 +22,11 @@ WWW::Pusher - Interface to the Pusher WebSockets API
 
 =head1 VERSION
 
-Version 0.06
+Version 0.07
 
 =cut
 
-our $VERSION = '0.06';
+our $VERSION = '0.07';
 
 =head1 SYNOPSIS
 

--- a/lib/WWW/Pusher.pm
+++ b/lib/WWW/Pusher.pm
@@ -63,7 +63,7 @@ sub new
 	die 'Pusher application ID must be defined' unless $args{app_id};
 
 	my $self = {
-		uri	 => URI->new($pusher_defaults->{host} || $args{host}),
+		uri	 => URI->new($args{host} || $pusher_defaults->{host}),
 		lwp	 => LWP::UserAgent->new,
 		debug    => $args{debug} || undef,
 		auth_key => $args{auth_key},

--- a/t/04-push_https.t
+++ b/t/04-push_https.t
@@ -1,0 +1,26 @@
+#!perl -T
+
+use Test::More;
+
+unless ( $ENV{PUSHERAPP_AUTHKEY} && $ENV{PUSHERAPP_APPID} && $ENV{PUSHERAPP_SECRET})
+{
+    plan( skip_all => "pusherapp.con API key not found, skipping..." );
+}
+
+use_ok('WWW::Pusher');
+
+my $pusher = WWW::Pusher->new(
+	host     => 'https://api.pusherapp.com',
+	port     => 443,
+	auth_key => $ENV{PUSHERAPP_AUTHKEY},
+	app_id   => $ENV{PUSHERAPP_APPID}, 
+	secret   => $ENV{PUSHERAPP_SECRET}, 
+	channel  => 'test_channel');
+
+ok($pusher, 'Created new WWW::Pusher object');
+
+my $time = scalar localtime;
+$pusher_response = $pusher->trigger(event =>'my_event', data =>'Testing WWW::Pusher at '.$time);
+is($pusher_response, '1', 'Sent trigger to pusher');
+
+done_testing();


### PR DESCRIPTION
There was a bug where if changing the host to use https://api.pusherapp.com for example the URI object was still created using the pusher default of http://api.pusherapp.com
